### PR TITLE
Handle version-less VM family names in find_similar_vm_families

### DIFF
--- a/cfa/cloudops/batch_helpers.py
+++ b/cfa/cloudops/batch_helpers.py
@@ -1993,7 +1993,10 @@ def find_similar_vm_families(
         return "".join(ch for ch in name.lower() if ch.isalnum())
 
     target_norm = normalize(family_name)
-    target_series, _target_attrs, target_version = get_vm_components(family_name)
+    try:
+        target_series, _target_attrs, target_version = get_vm_components(family_name)
+    except (IndexError, ValueError):
+        target_series, target_version = "", ""
 
     scored_names = []
     for candidate in available_names:

--- a/tests/test_batch_helpers.py
+++ b/tests/test_batch_helpers.py
@@ -11,6 +11,7 @@ from cfa.cloudops.batch_helpers import (
     check_mount_format,
     construct_vm_name,
     download_job_stats,
+    find_similar_vm_families,
     get_all_vm_quotas,
     get_args_from_yaml,
     get_full_container_image_name,
@@ -462,3 +463,19 @@ def test_get_vm_name_verify_unavailable_has_suggestions():
         excinfo.value
     )
     assert "Similar available VMs:" in str(excinfo.value)
+
+
+def test_find_similar_vm_families_versionless_target():
+    # A version-less family name like "standardDFamily" has no numeric version
+    # component, so get_vm_components raises ValueError on it. The candidate
+    # branch already guards this call; the target branch must too, otherwise
+    # asking for suggestions crashes instead of returning them.
+    quotas = [
+        {"name": "standardDASv5Family"},
+        {"name": "standardDDSv5Family"},
+    ]
+
+    for family in ("standardDFamily", "standardMSFamily"):
+        result = find_similar_vm_families(family, quotas=quotas)
+        assert isinstance(result, list)
+        assert all(name in {q["name"] for q in quotas} for name in result)


### PR DESCRIPTION
**Please describe the bug this fixes or the feature this adds.**

In `find_similar_vm_families` (cfa/cloudops/batch_helpers.py) the candidate `get_vm_components(candidate)` call is already wrapped in `try/except (IndexError, ValueError)`, but the target call `get_vm_components(family_name)` a few lines above it is not. `get_vm_components` runs `int()` on the trailing segment of the name, so a version-less family such as `standardDFamily` or `standardMSFamily` raises `ValueError: invalid literal for int() with base 10: 'd'`. That happens right when the helper is trying to build the "Similar available VMs" hint for `get_vm_name`, so instead of a helpful suggestion the caller gets a confusing crash from inside the suggestion path.

The change wraps the target call the same way the candidate call is already wrapped. If the requested name cannot be parsed, series/version fall back to empty strings and the function still returns similarity-ranked suggestions rather than raising. It is a small robustness fix that just makes the two sibling calls consistent.

**Please describe how you tested this change. Include unit tests whenever possible.**

Added `test_find_similar_vm_families_versionless_target` in tests/test_batch_helpers.py, which passes `standardDFamily` and `standardMSFamily` and asserts the call returns a list of valid quota names without raising. I confirmed it fails before the fix (the reverted code raises `ValueError` at the `int()` line) and passes after. Full module run is green locally:

```
uv run pytest tests/test_batch_helpers.py
22 passed in 5.39s
```

`ruff check` and `ruff format --check` both pass on the two edited files.

**Did you create or modify any associated documentation with this change? If documentation is not included in PR, please link to related documentation.**

No documentation changes. The behavior is internal to the helper and its docstring still holds.

**If you added or modified HTML, did you check that it was 508 compliant?**

Not applicable, no HTML was added or modified.

**Please tag any specific reviewers you would like to review this PR**

Happy to have whoever owns batch_helpers.py take a look; tagging is at your discretion.

**Please include the following checks for open source contributing?**

* [x] Did you check for sensitive data, and remove any?
* [x] Are additional approvals needed for this change?
* [x] Are there potential vulnerabilities or licensing issues with any new dependencies introduced? (no new dependencies)
